### PR TITLE
Fix/deploy position range

### DIFF
--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -8,14 +8,23 @@ const POPSICLE_V3_OPTIMIZER_PATH = "contracts/popsicle-v3-optimizer/PopsicleV3Op
 
 const UNISWAP_V3_FACTORY_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
-const FEE = 3000;
+function getUSDCAddress(networkName: string): string {
+  switch (networkName) {
+    case "localhost": // mainnet forking
+      return "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+    case "rinkeby":
+      return "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b";
+    default:
+      throw new Error(`Network ${networkName} not supported`)
+  }
+}
 
 function getDAIAddress(networkName: string): string {
   switch (networkName) {
     case "localhost": // mainnet forking
       return "0x6b175474e89094c44da98b954eedeac495271d0f";
     case "rinkeby":
-      return "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea";
+      return "0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735";
     default:
       throw new Error(`Network ${networkName} not supported`)
   }
@@ -32,10 +41,7 @@ function getWETHAddress(networkName: string): string {
   }
 }
 
-async function createUniswapPool() {
-  const daiAddress = getDAIAddress(network.name);
-  const wethAddress = getWETHAddress(network.name);
-
+async function createUniswapPool(token0Address: string, token1Address: string, fee: number) {
   const uniswapFactory = await ethers.getContractAt(
     UniswapV3FactoryArtifact.abi,
     UNISWAP_V3_FACTORY_ADDRESS,
@@ -43,9 +49,9 @@ async function createUniswapPool() {
 
   try {
     const createUniswapPoolTransaction = await uniswapFactory.createPool(
-      daiAddress,
-      wethAddress,
-      FEE,
+      token0Address,
+      token1Address,
+      fee,
       {
         gasLimit: 1000000,
       },
@@ -57,17 +63,27 @@ async function createUniswapPool() {
     // TODO: open a PR in Uniswap/v3-core to properly set fail codes
   }
 
-  const poolAddress = await uniswapFactory.getPool(daiAddress, wethAddress, FEE);
+  const poolAddress = await uniswapFactory.getPool(token0Address, token1Address, fee);
   if (ethers.BigNumber.from(poolAddress).eq(ethers.BigNumber.from(0))) {
     throw new Error("poolAddress is 0");
   }
 
   console.log(`poolAddress=${poolAddress}`)
+
+  const pool = await ethers.getContractAt(
+    UniswapV3PoolArtifact.abi,
+    poolAddress,
+  ) as UniswapV3Pool;
+  const slot0 = await pool.slot0();
+  const tickSpacing = await pool.tickSpacing();
+  console.log(`pool.tickSpacing=${tickSpacing}`);
+  console.log(`pool.slot0=${JSON.stringify(slot0)}`);
+
   return poolAddress;
 }
 
-async function main() {
-  const poolAddress = await createUniswapPool();
+async function deployPopsicle(token0Address: string, token1Address: string, fee: number) {
+  const poolAddress = await createUniswapPool(token0Address, token1Address, fee);
 
   const strategyFactory = await ethers.getContractFactory(OPTIMIZER_STRATEGY_PATH);
   const strategy = await strategyFactory.deploy(100, 40, 16, 2000, constants.MaxUint256) as OptimizerStrategy;
@@ -75,8 +91,24 @@ async function main() {
 
   const optimizerFactory = await ethers.getContractFactory(POPSICLE_V3_OPTIMIZER_PATH);
   const optimizerContract = (await optimizerFactory.deploy(poolAddress, strategy.address)) as PopsicleV3Optimizer;
-  await optimizerContract.init();
+  const initTransaction = await optimizerContract.init({ gasLimit: 1000000 });
+  await initTransaction.wait(2);
   console.log(`optimizerContract.address=${optimizerContract.address}`)
+}
+
+async function main() {
+  const daiAddress = getDAIAddress(network.name);
+  const wethAddress = getWETHAddress(network.name);
+  const usdcAddress = getUSDCAddress(network.name);
+
+  console.log("Deploying USDC/DAI 0.05");
+  await deployPopsicle(usdcAddress, daiAddress, 500);
+
+  console.log("Deploying USDC/WETH 0.3");
+  await deployPopsicle(usdcAddress, wethAddress, 3000);
+
+  console.log("Deploying WETH/DAI 0.3");
+  await deployPopsicle(wethAddress, daiAddress, 3000);
 }
 
 main()


### PR DESCRIPTION
PopsicleV3Optimizer fails if someone tries to deposit in a position that doesn't contains the current price.
It is not clear how Popsicle's team handles this in production, letting PopsicleV3Optimizer fail to deposit, or by trying to call rebalance periodically, etc.
This PR tries to avoid the necessity of calling rebalance periodically by setting a big position tick range.
This PR deploys position tick range almost as big as popsicle allows.
If price is out of this range then a smaller tick range will be necessary: https://github.com/Popsicle-Finance/PopsicleV3Optimizer/blob/c94a08c47a4d272a60a5924a6796bd0236567657/contracts/popsicle-v3-optimizer/PopsicleV3Optimizer.sol#L178, https://github.com/Popsicle-Finance/PopsicleV3Optimizer/blob/c94a08c47a4d272a60a5924a6796bd0236567657/contracts/popsicle-v3-optimizer/libraries/PoolVariables.sol#L120
So the supposition is that in test pools, prices are going to be in this range.